### PR TITLE
chore: Reduce artifact retention to 1 day

### DIFF
--- a/.github/workflows/chat_widget_build.yml
+++ b/.github/workflows/chat_widget_build.yml
@@ -33,5 +33,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 1
           name: chat-widget
           path: frontend/chat_widget/dist/chat-widget-bundle.js

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -131,6 +131,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
+          retention-days: 1
           name: cypress-screenshots
           path: frontend/smarty-pants/cypress/screenshots
 


### PR DESCRIPTION
## Summary
- Updates artifact retention period to 1 day
- Reduces GitHub Actions artifact storage costs

## Changes
- Modified workflow(s) to set `retention-days: 1` for `actions/upload-artifact@v4`

## Rationale
This change helps optimize GitHub Actions storage costs by reducing artifact retention to 1 day, which is sufficient for debugging recent workflow runs while preventing unnecessary long-term storage of build artifacts.